### PR TITLE
updating to new base images for arm remove need for qemu pull

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,4 @@
-FROM lsiobase/alpine.arm64:3.9
-
-# Add qemu to build on x86_64 systems
-COPY qemu-aarch64-static /usr/bin
+FROM lsiobase/alpine:arm64v8-3.9
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,7 +1,4 @@
-FROM lsiobase/alpine.armhf:3.9
-
-# Add qemu to build on x86_64 systems
-COPY qemu-arm-static /usr/bin
+FROM lsiobase/alpine:arm32v7-3.9
 
 # set version label
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -208,4 +208,5 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **19.05.19:** - Use new base images for arm versions.
 * **01.04.19:** - Initial Release

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -73,5 +73,6 @@ app_setup_block: |
   Once complete, you can log into the app via `http://your_ip_here:8080/login` to manage your repositories.
 
 # changelog
-changelogs: 
+changelogs:
+  - { date: "19.05.19:", desc: "Use new base images for arm versions." }
   - { date: "01.04.19:", desc: "Initial Release" }


### PR DESCRIPTION
this was never on the conversion list to get the new base images.